### PR TITLE
Preserving the genericness

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,10 @@ parameters:
 	ignoreErrors:
 		# https://github.com/phpstan/phpstan/issues/4078
 		-
+			message: "#^Method Tests\\\\Repositories\\\\ScheduleRepositoryTest\\:\\:createTargetReflection\\(\\) return type with generic class Cinemasunshine\\\\ORM\\\\Repositories\\\\ScheduleRepository does not specify its types\\: TScheduleEntity#"
+			path: tests/Repositories/ScheduleRepositoryTest.php
+			count: 1
+		-
 			message: "#^Method Tests\\\\Repositories\\\\TheaterRepositoryTest\\:\\:createTargetReflection\\(\\) return type with generic class Cinemasunshine\\\\ORM\\\\Repositories\\\\TheaterRepository does not specify its types\\: TTheaterEntity#"
 			path: tests/Repositories/TheaterRepositoryTest.php
 			count: 1

--- a/src/Repositories/ScheduleRepository.php
+++ b/src/Repositories/ScheduleRepository.php
@@ -9,7 +9,8 @@ use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\QueryBuilder;
 
 /**
- * @extends EntityRepository<Schedule>
+ * @template TScheduleEntity of Schedule
+ * @extends EntityRepository<TScheduleEntity>
  */
 class ScheduleRepository extends EntityRepository
 {

--- a/tests/Repositories/ScheduleRepositoryTest.php
+++ b/tests/Repositories/ScheduleRepositoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Repositories;
 
+use Cinemasunshine\ORM\Entities\Schedule;
 use Cinemasunshine\ORM\Repositories\ScheduleRepository;
 use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\TestCase;
@@ -11,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 final class ScheduleRepositoryTest extends TestCase
 {
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject&ScheduleRepository
+     * @return \PHPUnit\Framework\MockObject\MockObject&ScheduleRepository<Schedule>
      */
     protected function createTargetMock()
     {
@@ -20,7 +21,7 @@ final class ScheduleRepositoryTest extends TestCase
 
     /**
      * @param string[] $methods
-     * @return \PHPUnit\Framework\MockObject\MockObject&ScheduleRepository
+     * @return \PHPUnit\Framework\MockObject\MockObject&ScheduleRepository<Schedule>
      */
     public function createTargetPartialMock(array $methods)
     {


### PR DESCRIPTION
Repositoryクラスについて、親クラスのジェネリックを維持し、子クラスもジェネリックになるようにします。

[Class-level generics](https://phpstan.org/blog/generics-in-php-using-phpdocs#class-level-generics)